### PR TITLE
Fix compatibility issue about school attribute

### DIFF
--- a/src/main/java/de/cadentem/additional_attributes/compat/irons_spellbooks/SpellUtils.java
+++ b/src/main/java/de/cadentem/additional_attributes/compat/irons_spellbooks/SpellUtils.java
@@ -28,12 +28,16 @@ public class SpellUtils {
         ResourceLocation spellResource = spell.getSpellResource();
         ResourceLocation schoolResource = spell.getSchoolType().getId();
 
-        if (spellResource.getNamespace().equals(IronsSpellbooks.MODID)) {
-            // To keep compatibility with previous versions
+        if (schoolResource.getNamespace().equals(IronsSpellbooks.MODID)) {
             schoolAttribute = ForgeRegistries.ATTRIBUTES.getValue(new ResourceLocation(AA.MODID, ISAttributes.SCHOOL_PREFIX + schoolResource.getPath()));
-            spellAttribute = ForgeRegistries.ATTRIBUTES.getValue(new ResourceLocation(AA.MODID, ISAttributes.SPELL_PREFIX + spell.getSpellName()));
         } else {
             schoolAttribute = ForgeRegistries.ATTRIBUTES.getValue(new ResourceLocation(AA.MODID, ISAttributes.SCHOOL_PREFIX_NEW + schoolResource.getNamespace() + ISAttributes.SEPARATOR + schoolResource.getPath()));
+        }
+
+        if (spellResource.getNamespace().equals(IronsSpellbooks.MODID)) {
+            // To keep compatibility with previous versions
+            spellAttribute = ForgeRegistries.ATTRIBUTES.getValue(new ResourceLocation(AA.MODID, ISAttributes.SPELL_PREFIX + spell.getSpellName()));
+        } else {
             spellAttribute = ForgeRegistries.ATTRIBUTES.getValue(new ResourceLocation(AA.MODID, ISAttributes.SPELL_PREFIX_NEW + spellResource.getNamespace() + ISAttributes.SEPARATOR + spellResource.getPath()));
         }
 


### PR DESCRIPTION
https://github.com/SiverDX/additional_attributes/blob/1.20.1/src/main/java/de/cadentem/additional_attributes/compat/irons_spellbooks/SpellUtils.java#L36

this part is bugged when a modded spell uses iron's original school.
school and spell should have respective check.

<img width="2157" height="638" alt="image" src="https://github.com/user-attachments/assets/8ab942b1-92ef-4a0c-8dd7-57018c75bf39" />